### PR TITLE
Add YouTube bidding support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.pyc
+.env
+orders/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+discord.py
+python-dotenv
+google-api-python-client


### PR DESCRIPTION
## Summary
- load configuration from `.env`
- ignore `.env` and output order files
- add `requirements.txt`
- implement YouTube chat bidding and order file generation

## Testing
- `python -m py_compile bot.py`
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685a8ec77058832fbea00544b4ed6f0b