### PR TITLE
Fix decimal comma parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Auctions are loaded from a CSV file named `aukcje.csv` with columns:
 nazwa_karty,numer_karty,opis,cena_początkowa,kwota_przebicia,czas_trwania
 ```
 
+Values in `cena_początkowa` and `kwota_przebicia` may use either `.` or `,` as
+the decimal separator and will be parsed accordingly.
+
 Use the `/zaladuj` command (available only to the admin) to read this file and queue the auctions.
 
 ## Running

--- a/bot.py
+++ b/bot.py
@@ -59,8 +59,9 @@ class Aukcja:
         self.nazwa = nazwa
         self.numer = numer
         self.opis = opis
-        self.cena = float(cena_start)
-        self.przebicie = float(przebicie)
+        # Support both comma and dot as decimal separators
+        self.cena = float(str(cena_start).replace(",", "."))
+        self.przebicie = float(str(przebicie).replace(",", "."))
         self.czas = int(czas)
         self.historia = []
         self.zwyciezca = None


### PR DESCRIPTION
## Summary
- handle commas as decimal separators when loading auctions
- document decimal separator flexibility in README

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_685b96f8a3a0832faeda1ae992b658df