### PR TITLE
Add DM payment instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ python bot.py
    - `aktualna_aukcja.html` – summary page generated from `templates/auction_template.html`
    - `aktualna_aukcja.json` – machine‑readable auction data
    - `orders/` – text file with basic order information
-5. Po zakończeniu aukcji zwycięzca otrzymuje prywatną wiadomość z potwierdzeniem
-   zakupu i wyborem metody płatności. Po wybraniu bot publikuje zamówienie na
-   kanale wskazanym w `ORDER_CHANNEL_ID`, gdzie możesz je potwierdzić reakcją
+5. Po zakończeniu aukcji zwycięzca otrzymuje prywatną wiadomość z gratulacjami
+   i instrukcją wyboru metody płatności. W przyszłości wiadomość będzie zawierać
+   link do strony z płatnościami i wysyłką. Po wyborze bot publikuje zamówienie
+   na kanale wskazanym w `ORDER_CHANNEL_ID`, gdzie możesz je potwierdzić reakcją
    ✅. Potwierdzenie wysyła kupującemu finalną wiadomość o przyjęciu zamówienia.
 
 Feel free to modify `templates/auction_template.html` to change how the summary page looks.

--- a/bot.py
+++ b/bot.py
@@ -459,7 +459,8 @@ async def send_order_dm(aukcja: Aukcja):
     message = (
         f"Gratulacje! Wygrałeś licytację karty {aukcja.nazwa} {aukcja.numer} za {aukcja.cena:.2f} PLN.\n"
         f"Koszt wysyłki: 10,00 PLN (jeśli to Twoja pierwsza karta).\n"
-        "Wybierz metodę płatności i potwierdź zakup:"
+        "Wybierz metodę płatności i potwierdź zakup.\n"
+        "W przyszłości pojawi się tutaj link do strony z płatnościami i wysyłką."
     )
     try:
         if aukcja.obraz_url:


### PR DESCRIPTION
## Summary
- include a note about upcoming payment/shipping site in DM to the auction winner
- update README with details about the DM instructions

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_686250486f64832f9a7e3b593c8384ab