### PR TITLE
Improve auction UI

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -144,12 +144,12 @@ async def update_announcement_embed():
         embed.add_field(
             name="Cena",
             value=f"{aktualna_aukcja.cena:.2f} PLN",
-            inline=False,
+            inline=True,
         )
         embed.add_field(
             name="Prowadzi",
             value=f"{aktualna_aukcja.zwyciezca or 'Brak'}",
-            inline=False,
+            inline=True,
         )
 
         if aktualna_aukcja.start_time:
@@ -157,9 +157,9 @@ async def update_announcement_embed():
             pozostalo = int((koniec - datetime.datetime.utcnow()).total_seconds())
             pozostalo = max(pozostalo, 0)
             embed.add_field(
-                name="Koniec aukcji",
-                value=f"za {pozostalo}s",
-                inline=False,
+                name="Koniec za",
+                value=f"{pozostalo}s",
+                inline=True,
             )
 
         if aktualna_aukcja.obraz_url:
@@ -397,9 +397,9 @@ def zapisz_html(aukcja: Aukcja, template_path: str = "templates/auction_template
         template = Template(f.read())
 
     historia_html = ""
-    last = aukcja.historia[-4:]
+    last = list(reversed(aukcja.historia[-4:]))
     for i, (u, c, t) in enumerate(last):
-        strong = " font-weight:bold;" if i == len(last) - 1 else ""
+        strong = " font-weight:bold;" if i == 0 else ""
         historia_html += (
             f'<li style="{strong}"><span class="user">{u}</span> - '
             f'<span class="price">{c:.2f} PLN</span> - {t}</li>'

--- a/templates/auction_template.html
+++ b/templates/auction_template.html
@@ -33,7 +33,7 @@
 </head>
 <body class="min-h-screen bg-gradient-to-br from-[#1e1e30] to-[#121220] text-gray-100" onload="startUpdates()">
 <div class="backdrop-blur-md bg-black/40 min-h-screen p-8">
-    <div id="auction" class="bg-[#191926b3] backdrop-blur-sm p-8 rounded-xl max-w-2xl mx-auto shadow-xl">
+    <div id="auction" class="bg-white/10 backdrop-blur-lg p-8 rounded-xl max-w-2xl mx-auto shadow-xl">
         <h1 id="title" class="text-yellow-300 text-center font-semibold text-3xl mb-2">${nazwa} (${numer})</h1>
         <p id="desc" class="mb-4">${opis}</p>
         <img id="card-img" src="${obraz}" class="mx-auto mb-4 max-w-full" style="display:none"/>
@@ -93,7 +93,7 @@ function fetchData(){
         if(data.historia){
             const newStamp = data.historia[data.historia.length-1]?.[2] || null;
             const isNew = newStamp && newStamp !== lastHistoryStamp;
-            historyData = data.historia.slice(-perPage);
+            historyData = data.historia.slice(-perPage).reverse();
             lastHistoryStamp = newStamp;
             renderHistory(isNew);
         }
@@ -144,7 +144,7 @@ function renderHistory(newItem=false){
     historyData.forEach(([u,c,t], idx)=>{
         const li = document.createElement('li');
         li.innerHTML = `<span class="user">${u}</span> - <span class="price">${c.toFixed(2)} PLN</span> - ${t}`;
-        if(newItem && idx === historyData.length - 1){
+        if(newItem && idx === 0){
             li.classList.add('font-bold');
             setTimeout(()=>li.classList.remove('font-bold'), 2000);
         }


### PR DESCRIPTION
## Summary
- show time, leader and countdown inline in the announcement embed
- reverse bid history order with newest bids at top
- polish auction page look with blurred transparent background

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686266358e78832fabbf111d756040ab