### PR TITLE
Update auction page layout

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -398,11 +398,11 @@ def zapisz_html(aukcja: Aukcja, template_path: str = "templates/auction_template
 
     historia_html = ""
     last = list(reversed(aukcja.historia[-4:]))
-    for i, (u, c, t) in enumerate(last):
+    for i, (u, c, _t) in enumerate(last):
         strong = " font-weight:bold;" if i == 0 else ""
         historia_html += (
             f'<li style="{strong}"><span class="user">{u}</span> - '
-            f'<span class="price">{c:.2f} PLN</span> - {t}</li>'
+            f'<span class="price">{c:.2f} PLN</span></li>'
         )
 
     html = template.safe_substitute(
@@ -540,6 +540,14 @@ async def zakoncz_aukcje(msg):
             pass
 
         await announce_winner(aktualna_aukcja)
+
+        if aktualna_aukcja.zwyciezca:
+            try:
+                await msg.channel.send(
+                    f"Gratuluję!\nwygrał: {aktualna_aukcja.zwyciezca}\nczekaj na wiadomość DM"
+                )
+            except discord.HTTPException:
+                pass
 
         if aktualna_aukcja.zwyciezca:
             zapisz_zamowienie(aktualna_aukcja)

--- a/templates/auction_template.html
+++ b/templates/auction_template.html
@@ -31,9 +31,9 @@
         }
     </style>
 </head>
-<body class="min-h-screen bg-gradient-to-br from-[#1a1a29] to-[#0d0d17] text-gray-100" onload="startUpdates()">
+<body class="min-h-screen text-gray-100" onload="startUpdates()">
 <div class="p-4 sm:p-8">
-    <div id="auction" class="bg-white/10 backdrop-blur-lg p-6 sm:p-8 rounded-xl max-w-4xl mx-auto shadow-xl">
+    <div id="auction" class="p-6 sm:p-8 rounded-xl max-w-5xl mx-auto">
         <div class="grid md:grid-cols-2 gap-6">
             <div class="flex flex-col items-center">
                 <img id="card-img" src="${obraz}" class="w-full rounded-lg shadow-lg mb-4 hidden" />
@@ -105,7 +105,7 @@ function fetchData(){
         if(data.historia){
             const newStamp = data.historia[data.historia.length-1]?.[2] || null;
             const isNew = newStamp && newStamp !== lastHistoryStamp;
-            historyData = data.historia.slice(-perPage).reverse();
+            historyData = data.historia.slice(-perPage).map(h => [h[0], h[1]]).reverse();
             lastHistoryStamp = newStamp;
             renderHistory(isNew);
         }
@@ -146,7 +146,7 @@ function showWinner(data){
     winnerEl.style.display='block';
     winnerEl.classList.add('fade-in');
     if(data.zwyciezca){
-        winnerEl.innerHTML = `Gratulacje! Aukcję wygrał: <span class="text-yellow-300 font-bold">${data.zwyciezca}</span> - ${data.nazwa}`;
+        winnerEl.innerHTML = `Gratuluję!<br/>wygrał: <span class="text-yellow-300 font-bold">${data.zwyciezca}</span><br/>czekaj na wiadomość DM`;
     } else {
         winnerEl.textContent = 'Aukcja zakończona bez zwycięzcy';
     }
@@ -159,9 +159,9 @@ function showWinner(data){
 function renderHistory(newItem=false){
     const list = document.getElementById('history');
     list.innerHTML = '';
-    historyData.forEach(([u,c,t], idx)=>{
+    historyData.forEach(([u,c], idx)=>{
         const li = document.createElement('li');
-        li.innerHTML = `<span class="user">${u}</span> - <span class="price">${c.toFixed(2)} PLN</span> - ${t}`;
+        li.innerHTML = `<span class="user">${u}</span> - <span class="price">${c.toFixed(2)} PLN</span>`;
         if(idx === 0){
             li.classList.add('text-indigo-300');
             if(newItem){


### PR DESCRIPTION
## Summary
- widen auction page and remove gradient background
- show short bid history without timestamps
- display winner message instructing them to check DM
- send congratulation message when auction ends

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68627a2478f8832fa4d14beea49a304f