### PR TITLE
Fix auction output paths and add blurred background

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ python bot.py
 2. Use the **Następna karta** button on the panel to begin the next auction. The bot posts an embed with item details on the bidding channel and a **🔼 LICYTUJ** button.
 3. Participants click the button to increase the price by the configured increment. Messages containing `!bit` in the configured YouTube live chat also count as bids if YouTube integration is enabled.
 4. When the timer expires the auction ends. The winner and final price are announced and saved to:
-   - `aktualna_aukcja.html` – summary page generated from `templates/auction_template.html`
-   - `aktualna_aukcja.json` – machine‑readable auction data
+   - `templates/aktualna_aukcja.html` – summary page generated from `templates/auction_template.html`
+   - `templates/aktualna_aukcja.json` – machine‑readable auction data
    - `orders/` – text file with basic order information
 5. Po zakończeniu aukcji zwycięzca otrzymuje prywatną wiadomość z gratulacjami
    i instrukcją wyboru metody płatności. W przyszłości wiadomość będzie zawierać

--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import discord
 from discord.ext import commands, tasks
 import csv
@@ -26,6 +27,10 @@ OGLOSZENIA_KANAL_ID = int(os.getenv("OGLOSZENIA_KANAL_ID", "0"))
 YOUTUBE_API_KEY = os.getenv("YOUTUBE_API_KEY")
 LIVE_CHAT_ID = os.getenv("LIVE_CHAT_ID")
 POKEMONTCG_API_TOKEN = os.getenv("POKEMONTCG_API_TOKEN")
+
+# Directory where aktualna_aukcja.html and aktualna_aukcja.json are stored
+OUTPUT_DIR = Path("templates")
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 bot = commands.Bot(command_prefix='/', intents=discord.Intents.all())
 
@@ -415,7 +420,8 @@ def zapisz_html(aukcja: Aukcja, template_path: str = "templates/auction_template
         obraz=aukcja.obraz_url or "",
     )
 
-    with open("aktualna_aukcja.html", "w", encoding="utf-8") as f:
+    out_html = OUTPUT_DIR / "aktualna_aukcja.html"
+    with open(out_html, "w", encoding="utf-8") as f:
         f.write(html)
 
 def zapisz_json(aukcja: Aukcja):
@@ -431,7 +437,8 @@ def zapisz_json(aukcja: Aukcja):
         "obraz": aukcja.obraz_url,
         "logo": aukcja.logo_url,
     }
-    with open('aktualna_aukcja.json', 'w', encoding='utf-8') as f:
+    out_json = OUTPUT_DIR / 'aktualna_aukcja.json'
+    with open(out_json, 'w', encoding='utf-8') as f:
         json.dump(dane, f, ensure_ascii=False, indent=2)
 
 def generate_order_number() -> str:

--- a/templates/auction_template.html
+++ b/templates/auction_template.html
@@ -33,7 +33,7 @@
 </head>
 <body class="min-h-screen text-gray-100" onload="startUpdates()">
 <div class="p-4 sm:p-8">
-    <div id="auction" class="p-6 sm:p-8 rounded-xl max-w-5xl mx-auto">
+    <div id="auction" class="p-6 sm:p-8 rounded-xl max-w-5xl mx-auto bg-black/40 backdrop-blur">
         <div class="grid md:grid-cols-2 gap-6">
             <div class="flex flex-col items-center">
                 <img id="card-img" src="${obraz}" class="w-full rounded-lg shadow-lg mb-4 hidden" />


### PR DESCRIPTION
## Summary
- store generated auction summary files inside `templates/`
- document new locations in README
- apply a blurred semi-transparent background to the auction container

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68627e4275c8832f871f1042c0f3196d