### PR TITLE
Update auction page visuals

### DIFF
--- a/templates/auction_template.html
+++ b/templates/auction_template.html
@@ -9,12 +9,13 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
         body { font-family: 'Poppins', Helvetica, sans-serif; }
+        #price { position:relative; padding-right:1.2em; }
         #countdown.red { color:#ff6464; }
         #price.up::after {
             content:'\25B2';
             color:#67e8f9;
             position:absolute;
-            right:-0.6em;
+            right:0;
             top:0;
             animation:rise 0.6s ease-out;
         }
@@ -31,7 +32,7 @@
         }
     </style>
 </head>
-<body class="min-h-screen text-gray-100" onload="startUpdates()">
+<body class="min-h-screen text-gray-100 bg-black/60 backdrop-blur" onload="startUpdates()">
 <div class="p-4 sm:p-8">
     <div id="auction" class="p-6 sm:p-8 rounded-xl max-w-5xl mx-auto bg-black/40 backdrop-blur">
         <div class="grid md:grid-cols-2 gap-6">
@@ -146,7 +147,7 @@ function showWinner(data){
     winnerEl.style.display='block';
     winnerEl.classList.add('fade-in');
     if(data.zwyciezca){
-        winnerEl.innerHTML = `Gratuluję!<br/>wygrał: <span class="text-yellow-300 font-bold">${data.zwyciezca}</span><br/>czekaj na wiadomość DM`;
+        winnerEl.textContent = `Gratuluję! wygrał: ${data.zwyciezca} czekaj na wiadomość dm`;
     } else {
         winnerEl.textContent = 'Aukcja zakończona bez zwycięzcy';
     }
@@ -154,6 +155,10 @@ function showWinner(data){
     document.getElementById('price').style.display='none';
     document.getElementById('history').style.display='none';
     document.getElementById('history').innerHTML='';
+    document.getElementById('countdown').style.display='none';
+    document.getElementById('progress').style.display='none';
+    document.getElementById('title').style.display='none';
+    document.getElementById('card-img').style.display='none';
 }
 
 function renderHistory(newItem=false){
@@ -163,7 +168,7 @@ function renderHistory(newItem=false){
         const li = document.createElement('li');
         li.innerHTML = `<span class="user">${u}</span> - <span class="price">${c.toFixed(2)} PLN</span>`;
         if(idx === 0){
-            li.classList.add('text-indigo-300');
+            li.classList.add('text-indigo-300','text-lg');
             if(newItem){
                 li.classList.add('font-bold');
                 setTimeout(()=>li.classList.remove('font-bold'), 2000);


### PR DESCRIPTION
## Summary
- tweak arrow animation layout and move it away from the price
- enlarge newest entry in bid history
- display only a short congratulation message when the auction ends
- darken page background with a blurred overlay

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_686280971008832f94c24cda49ce479f