### PR TITLE
Improve auction display and next card info

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -425,6 +425,8 @@ def zapisz_html(aukcja: Aukcja, template_path: str = "templates/auction_template
         f.write(html)
 
 def zapisz_json(aukcja: Aukcja):
+    next_nazwa = aukcje_kolejka[0].nazwa if aukcje_kolejka else None
+    next_numer = aukcje_kolejka[0].numer if aukcje_kolejka else None
     dane = {
         "nazwa": aukcja.nazwa,
         "numer": aukcja.numer,
@@ -436,6 +438,8 @@ def zapisz_json(aukcja: Aukcja):
         "czas": aukcja.czas,
         "obraz": aukcja.obraz_url,
         "logo": aukcja.logo_url,
+        "next_nazwa": next_nazwa,
+        "next_numer": next_numer,
     }
     out_json = OUTPUT_DIR / 'aktualna_aukcja.json'
     with open(out_json, 'w', encoding='utf-8') as f:

--- a/templates/auction_template.html
+++ b/templates/auction_template.html
@@ -37,16 +37,17 @@
     <div id="auction" class="p-6 sm:p-8 rounded-xl max-w-5xl mx-auto bg-black/40 backdrop-blur">
         <div class="grid md:grid-cols-2 gap-6">
             <div class="flex flex-col items-center">
+                <h1 id="title" class="text-yellow-300 text-center font-semibold text-3xl mb-2">${nazwa} (${numer})</h1>
                 <img id="card-img" src="${obraz}" class="w-full rounded-lg shadow-lg mb-4 hidden" />
                 <h2 id="price" class="text-cyan-300 text-center font-bold text-6xl drop-shadow mb-4">${cena} PLN</h2>
-                <div class="w-full bg-gray-700 rounded h-3 mb-4 overflow-hidden">
+                <div class="w-full bg-gray-700 rounded h-3 mb-2 overflow-hidden">
                     <div id="progress" class="bg-cyan-400 h-full" style="width:100%"></div>
                 </div>
                 <div id="countdown" class="text-5xl font-semibold text-center mb-4 animate-pulse"></div>
                 <h3 id="winner" class="text-green-400 text-center text-3xl font-bold" style="display:none"></h3>
+                <p id="next-info" class="text-yellow-300 text-center text-xl mt-2" style="display:none"></p>
             </div>
             <div>
-                <h1 id="title" class="text-yellow-300 text-center md:text-left font-semibold text-3xl mb-2">${nazwa} (${numer})</h1>
                 <p id="desc" class="mb-4">${opis}</p>
                 <h4 class="text-yellow-300 font-semibold mb-2">Historia licytacji:</h4>
                 <ul id="history" class="list-none pl-0 space-y-1 max-h-28 overflow-y-auto pr-2">
@@ -74,6 +75,7 @@ function fetchData(){
     fetch('aktualna_aukcja.json',{cache:'no-cache'}).then(r=>r.json()).then(data=>{
         const list = document.getElementById('history');
         const img = document.getElementById('card-img');
+        const nextEl = document.getElementById('next-info');
 
         if(!lastStart || lastStart !== data.start_time){
             historyData = [];
@@ -86,6 +88,7 @@ function fetchData(){
             lastPrice = null;
             lastStart = data.start_time;
             document.getElementById('progress').style.width = '100%';
+            nextEl.style.display = 'none';
             renderHistory();
         }
 
@@ -144,13 +147,20 @@ function updateCountdown(){
 }
 function showWinner(data){
     const winnerEl = document.getElementById('winner');
+    const nextEl = document.getElementById('next-info');
     winnerEl.style.display='block';
     winnerEl.classList.add('fade-in');
     if(data.zwyciezca){
-        winnerEl.textContent = `Gratuluję! wygrał: ${data.zwyciezca} czekaj na wiadomość dm`;
+        winnerEl.textContent = `Gratuluję! wygrał: ${data.zwyciezca}`;
     } else {
         winnerEl.textContent = 'Aukcja zakończona bez zwycięzcy';
     }
+    if(data.next_nazwa){
+        nextEl.textContent = `Następna licytacja: ${data.next_nazwa} (${data.next_numer})`;
+    } else {
+        nextEl.textContent = 'Brak kolejnych licytacji';
+    }
+    nextEl.style.display='block';
     document.getElementById('desc').style.display='none';
     document.getElementById('price').style.display='none';
     document.getElementById('history').style.display='none';


### PR DESCRIPTION
## Summary
- show card name on the left next to timer and price
- display info about the next auction after bidding ends
- output next card info into `aktualna_aukcja.json`

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6862895add10832f92b8ea1016a3507c