### PR TITLE
Restore countdown timer and show winner details

### DIFF
--- a/templates/auction_template.html
+++ b/templates/auction_template.html
@@ -44,15 +44,15 @@
                     <div id="progress" class="bg-cyan-400 h-full" style="width:100%"></div>
                 </div>
                 <div id="countdown" class="text-5xl font-semibold text-center mb-4 animate-pulse"></div>
+                <h4 class="text-yellow-300 font-semibold mb-2">Historia licytacji:</h4>
+                <ul id="history" class="list-none pl-0 space-y-1 max-h-28 overflow-y-auto pr-2 mb-4">
+                    ${historia}
+                </ul>
                 <h3 id="winner" class="text-green-400 text-center text-3xl font-bold" style="display:none"></h3>
-                <p id="next-info" class="text-yellow-300 text-center text-xl mt-2" style="display:none"></p>
+                <p id="next-info" class="text-yellow-300 text-center text-xl mt-4" style="display:none"></p>
             </div>
             <div>
                 <p id="desc" class="mb-4">${opis}</p>
-                <h4 class="text-yellow-300 font-semibold mb-2">Historia licytacji:</h4>
-                <ul id="history" class="list-none pl-0 space-y-1 max-h-28 overflow-y-auto pr-2">
-                    ${historia}
-                </ul>
             </div>
         </div>
     </div>
@@ -151,7 +151,7 @@ function showWinner(data){
     winnerEl.style.display='block';
     winnerEl.classList.add('fade-in');
     if(data.zwyciezca){
-        winnerEl.textContent = `Gratuluję! wygrał: ${data.zwyciezca}`;
+        winnerEl.innerHTML = `Gratulację!<br>wygrał <span class="text-cyan-300 text-4xl">${data.zwyciezca}</span>`;
     } else {
         winnerEl.textContent = 'Aukcja zakończona bez zwycięzcy';
     }
@@ -161,14 +161,6 @@ function showWinner(data){
         nextEl.textContent = 'Brak kolejnych licytacji';
     }
     nextEl.style.display='block';
-    document.getElementById('desc').style.display='none';
-    document.getElementById('price').style.display='none';
-    document.getElementById('history').style.display='none';
-    document.getElementById('history').innerHTML='';
-    document.getElementById('countdown').style.display='none';
-    document.getElementById('progress').style.display='none';
-    document.getElementById('title').style.display='none';
-    document.getElementById('card-img').style.display='none';
 }
 
 function renderHistory(newItem=false){


### PR DESCRIPTION
## Summary
- show auction history under the countdown timer
- keep timer visible when auction ends and display winner with colored username

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68628be12878832f9602acfcf8db15e3